### PR TITLE
Fix windows support and add configuration options

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -3,7 +3,7 @@ path = require 'path'
 
 lint = (editor) ->
   helpers = require('atom-linter')
-  regex = /([^:]+):([^:]+):(.+)/
+  regex = /((?:[A-Z]:)?[^:]+):([^:]+):(.+)/
   file = editor.getPath()
   dirname = path.dirname(file)
 

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -6,14 +6,17 @@ lint = (editor) ->
   regex = /((?:[A-Z]:)?[^:]+):([^:]+):(.+)/
   file = editor.getPath()
   dirname = path.dirname(file)
-
-  helpers.exec('iverilog', ['-t', 'null', '-I', dirname,  file], {stream: 'both'}).then (output) ->
+  
+  args = ("#{arg}" for arg in atom.config.get('linter-verilog.extraOptions'))
+  args = args.concat ['-t', 'null', '-I', dirname,  file]
+  helpers.exec('iverilog', args, {stream: 'both'}).then (output) ->
     lines = output.stderr.split("\n")
     messages = []
     for line in lines
       if line.length == 0
         continue;
 
+      console.log(line)
       parts = line.match(regex)
       if !parts || parts.length != 4
         console.debug("Droping line:", line)
@@ -29,6 +32,11 @@ lint = (editor) ->
     return messages
 
 module.exports =
+  config:
+    extraOptions:
+      type: 'array'
+      default: []
+      description: 'Comma separated list of iverilog options'
   activate: ->
     require('atom-package-deps').install('linter-verilog')
 


### PR DESCRIPTION
Fixes the regex as in a comment I made on issue #1, and adds a configuration option so you can set extra options (like systemverilog support).