### PR TITLE
Add support for Verilator as default linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#linter-verilog
+# linter-verilog
 
 Atom linter for Verilog and SystemVerilog using [Verilaror](http://www.veripool.org/wiki/verilator).
 
@@ -7,7 +7,7 @@ There is also an option use [Icarus Verilog](http://iverilog.icarus.com) which o
 ![Screenshot](https://raw.githubusercontent.com/manucorporat/linter-verilog/master/screenshot.png)
 
 
-#Installation
+# Installation
 
 1. Install one of the supported simulators
 
@@ -25,7 +25,7 @@ On MacOs, they should be available using **`brew`**.
 If you are writing SystemVerilog, you will have to install **Verilator** as iverilog does not support recent Verilog Syntax.
 
 
-2. Install the atom package:  
+2. Install the atom package: 
 
 From the `Install` pane of the `Settings` menu or through the command line:
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,34 @@
 #linter-verilog
 
-Atom linter for Verilog, using [Icarus Verilog](http://iverilog.icarus.com).  
+Atom linter for Verilog and SystemVerilog using [Verilaror](http://www.veripool.org/wiki/verilator).
+
+There is also an option use [Icarus Verilog](http://iverilog.icarus.com) which only supports old Verilog.
 
 ![Screenshot](https://raw.githubusercontent.com/manucorporat/linter-verilog/master/screenshot.png)
 
 
 #Installation
 
-1. [Install icarus verilog](http://www.swarthmore.edu/NatSci/mzucker1/e15_f2014/iverilog.html).  
-On OSX you can just use **brew**:  
+1. Install one of the supported simulators
 
- ```
-$ brew install icarus-verilog
+`Verilator` and `iverilog`/`icarus-verilog` are both opensource softwares and you should find a corresponding package for your Linux Distribution.
+
+On Debian derivatives, it should be as easy as:
+
+```
+$ apt-get install verilator
+$ apt-get install iverilog
 ```
 
-2. Install atom package:  
+On MacOs, they should be available using **`brew`**.
 
- ```
+If you are writing SystemVerilog, you will have to install **Verilator** as iverilog does not support recent Verilog Syntax.
+
+
+2. Install the atom package:  
+
+From the `Install` pane of the `Settings` menu or through the command line:
+
+```
 $ apm install linter-verilog
 ```

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -81,7 +81,7 @@ module.exports =
       enum: ['verilator', 'iverilog']
     extraOptions:
       type: 'array'
-      default: ['--default-language','1800-2012']
+      default: []
       description: 'Comma separated list of iverilog options'
   activate: ->
     require('atom-package-deps').install('linter-verilog')

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "linter-verilog",
   "main": "./lib/init",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Atom linter for Verilog, using icarus verilog.",
   "keywords": [
     "verilog",
+    "systemverilog",
+    "verilator",
     "iverilog",
     "icarus",
     "linter",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "linter-verilog",
   "main": "./lib/init",
-  "version": "0.7.1",
-  "description": "Atom linter for Verilog, using icarus verilog.",
+  "version": "0.7.0",
+  "description": "Atom linter for Verilog/SystemVerilog, using verilator or icarus verilog.",
   "keywords": [
     "verilog",
     "systemverilog",


### PR DESCRIPTION
Hi there and thanks for your package.
I have added support for verilator as an additional compiler and added an option to choose between the the two.
I have set **verilator** as the default compiler, because I think that the returned info are better and it supports modern dialects of Verilog and SystemVerilog.

I'm new to coffescript so my code may not be as elegant as it should be.

Tarik